### PR TITLE
Fix: BoardGame 엔티티에 BoardGameTag 매핑 추가

### DIFF
--- a/src/main/java/com/swyp/boardpick/domain/BoardGame.java
+++ b/src/main/java/com/swyp/boardpick/domain/BoardGame.java
@@ -29,4 +29,7 @@ public class BoardGame {
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "boardGame")
     List<UserBoardGame> userBoardGames = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "boardGame")
+    List<BoardGameTag> boardGameTags = new ArrayList<>();
 }

--- a/src/main/java/com/swyp/boardpick/service/implement/BoardGameService.java
+++ b/src/main/java/com/swyp/boardpick/service/implement/BoardGameService.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 public class BoardGameService {
     private final BoardGameRepository boardGameRepository;
     private final BoardGameCategoryRepository boardGameCategoryRepository;
-    private final BoardGameTagRepository boardGameTagRepository;
     private final CategoryRepository categoryRepository;
 
 
@@ -32,9 +31,9 @@ public class BoardGameService {
         return boardGameCategoryRepository.findByCategory_Id(categoryId, PageRequest.of(page, size))
                 .stream().map(boardGameCategory -> {
                     BoardGame boardGame = boardGameCategory.getBoardGame();
-                    List<String> tags = boardGameTagRepository.findBoardGameTagByBoardGame(boardGame)
-                            .stream().map(boardGameTag -> boardGameTag.getTag().getContent()).toList();
-
+                    List<String> tags = boardGame.getBoardGameTags()
+                            .stream().map(boardGameTag -> boardGameTag.getTag().getContent())
+                            .toList();
                     return new BoardGameDto(boardGame, tags);
                 }).toList();
     }

--- a/src/main/java/com/swyp/boardpick/service/implement/UserService.java
+++ b/src/main/java/com/swyp/boardpick/service/implement/UserService.java
@@ -1,7 +1,9 @@
 package com.swyp.boardpick.service.implement;
 
+import com.swyp.boardpick.domain.BoardGame;
 import com.swyp.boardpick.domain.User;
 import com.swyp.boardpick.dto.response.BoardGameDto;
+import com.swyp.boardpick.repository.BoardGameRepository;
 import com.swyp.boardpick.repository.BoardGameTagRepository;
 import com.swyp.boardpick.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -14,7 +16,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
-    private final BoardGameTagRepository boardGameTagRepository;
 
     public Long getUserId(String userCode) {
         User user = userRepository.findByCode(userCode)
@@ -26,8 +27,10 @@ public class UserService {
         return userRepository.findById(id)
                 .get().getUserBoardGames()
                 .stream().map(userBoardGame -> {
-                    List<String> tags = boardGameTagRepository.findBoardGameTagByBoardGame(userBoardGame.getBoardGame())
-                            .stream().map(boardGameTag -> boardGameTag.getTag().getContent()).toList();
+                    BoardGame boardGame = userBoardGame.getBoardGame();
+                    List<String> tags = boardGame.getBoardGameTags()
+                            .stream().map(boardGameTag -> boardGameTag.getTag().getContent())
+                            .toList();
                     return new BoardGameDto(userBoardGame.getBoardGame(), tags);
                 })
                 .toList();


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

`BoardGame` 엔티티에 `BoardGameTag`와 연결관계 추가

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->


```Java
@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "boardGame")
List<BoardGameTag> boardGameTags = new ArrayList<>();
```

```Java
public List<BoardGameDto> getBoardGamesByCategory(String category, int page, int size) {
        Long categoryId = categoryRepository.findByType(category).getId();
        return boardGameCategoryRepository.findByCategory_Id(categoryId, PageRequest.of(page, size))
                .stream().map(boardGameCategory -> {
                    BoardGame boardGame = boardGameCategory.getBoardGame();
                    List<String> tags = boardGame.getBoardGameTags()
                            .stream().map(boardGameTag -> boardGameTag.getTag().getContent())
                            .toList();
                    return new BoardGameDto(boardGame, tags);
                }).toList();
    }
```
Service에서 보드게임 조회 로직도 수정했습니다.