### PR TITLE
Feature: 보드게임 검색 기능 구현

### DIFF
--- a/src/main/java/com/swyp/boardpick/controller/BoardGameController.java
+++ b/src/main/java/com/swyp/boardpick/controller/BoardGameController.java
@@ -36,7 +36,13 @@ public class BoardGameController {
     @GetMapping
     @ResponseBody
     public List<BoardGameDto> getBoardgamesByCategory(
-            @RequestParam String category, @RequestParam int page, @RequestParam int size) {
+            @RequestParam String category, @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
         return boardGameService.getBoardGamesByCategory(category, page, size);
+    }
+
+    @GetMapping("/search")
+    public List<BoardGameDto> searchBoardGames(
+            @RequestParam String keyword, @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
+        return boardGameService.searchBoardGames(keyword, page, size);
     }
 }

--- a/src/main/java/com/swyp/boardpick/dto/response/BoardGameDto.java
+++ b/src/main/java/com/swyp/boardpick/dto/response/BoardGameDto.java
@@ -18,6 +18,7 @@ public class BoardGameDto {
     private String description;
     private double rating;
     private int ratingCount;
+    private boolean picked;
     private List<String> tags;
     public BoardGameDto(BoardGame boardGame, List<String> tags) {
         this.id = boardGame.getId();
@@ -28,5 +29,18 @@ public class BoardGameDto {
         this.rating = boardGame.getRating();
         this.ratingCount = boardGame.getRatingCount();
         this.tags = tags;
+        this.picked = true;
+    }
+
+    public BoardGameDto(BoardGame boardGame, List<String> tags, boolean picked) {
+        this.id = boardGame.getId();
+        this.thumbnailUrl = boardGame.getThumbnailUrl();
+        this.imageUrl = boardGame.getImageUrl();
+        this.name = boardGame.getName();
+        this.description = boardGame.getDescription();
+        this.rating = boardGame.getRating();
+        this.ratingCount = boardGame.getRatingCount();
+        this.tags = tags;
+        this.picked = picked;
     }
 }

--- a/src/main/java/com/swyp/boardpick/repository/BoardGameRepository.java
+++ b/src/main/java/com/swyp/boardpick/repository/BoardGameRepository.java
@@ -1,7 +1,11 @@
 package com.swyp.boardpick.repository;
 
 import com.swyp.boardpick.domain.BoardGame;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BoardGameRepository extends JpaRepository<BoardGame, Long> {
+    List<BoardGame> findByNameContaining(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/swyp/boardpick/service/implement/OAuth2UserServiceImplement.java
+++ b/src/main/java/com/swyp/boardpick/service/implement/OAuth2UserServiceImplement.java
@@ -58,4 +58,5 @@ public class OAuth2UserServiceImplement extends DefaultOAuth2UserService {
 
         return new CustomOAuth2User(userCode, authorities);
     }
+
 }

--- a/src/main/java/com/swyp/boardpick/service/implement/UserService.java
+++ b/src/main/java/com/swyp/boardpick/service/implement/UserService.java
@@ -8,6 +8,10 @@ import com.swyp.boardpick.repository.BoardGameTagRepository;
 import com.swyp.boardpick.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,6 +25,18 @@ public class UserService {
         User user = userRepository.findByCode(userCode)
                 .orElseThrow(() -> new EntityNotFoundException("User not found with code: " + userCode));
         return user.getId();
+    }
+
+    public Long getCurrentOAuth2UserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
+
+            OAuth2User oauthUser = oauthToken.getPrincipal();
+            return getUserId(oauthUser.getName());
+        }
+
+        return null;
     }
 
     public List<BoardGameDto> getMyPickList(Long id) {


### PR DESCRIPTION

## 작업 개요
키워드를 통한 보드게임 검색 기능 구현
api 호출 예시: `/api/boardgames/search?keyword=셀레&page=0&size=10`

## 작업 사항
- 이름에 키워드가 포함되어 있는 보드게임 리스트 반환
- UserService에 현재 접속한 유저의 userId값 가져오는 함수 추가
- userId와 boardGameId를 통해 picked 여부 가져오기

## 추가 사항
picked 정보 가져오는 부분이 많을거 같아 코드 공유 합니다.
```java
Long userId = userService.getCurrentOAuth2UserId();
Long boardGameId = boardGame.getId();
boolean picked = userBoardGameRepository.existsByUserIdAndBoardGameId(userId, boardGameId);
```

