### PR TITLE
Fix: jwt API 요청 인증 프로세스 수정

### DIFF
--- a/src/main/java/com/swyp/boardpick/config/WebSecurityConfig.java
+++ b/src/main/java/com/swyp/boardpick/config/WebSecurityConfig.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
@@ -50,8 +51,7 @@ public class WebSecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/api/pick/**").authenticated()
-                        .requestMatchers("/api/user/**").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/**").authenticated()
                         .requestMatchers("/user/**").hasRole("USER")
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().permitAll()
@@ -60,9 +60,6 @@ public class WebSecurityConfig {
                         .redirectionEndpoint(endpoint -> endpoint.baseUri("/oauth2/callback/*"))
                         .userInfoEndpoint(endpoint -> endpoint.userService(oAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
-                )
-                .exceptionHandling(exceptionHandling -> exceptionHandling
-                        .authenticationEntryPoint(new FailedAuthenticationEntryPoint())
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .logout(logout -> logout
@@ -82,6 +79,7 @@ public class WebSecurityConfig {
         corsConfiguration.addAllowedOrigin(Uri.MAIN_PAGE.getDescription());
         corsConfiguration.addAllowedOrigin("http://localhost:3000");
         corsConfiguration.addAllowedOrigin("http://localhost:8080");
+//        corsConfiguration.addAllowedOrigin("https://accounts.kakao.com");
         corsConfiguration.setAllowCredentials(true);
         corsConfiguration.addAllowedMethod("*");
         corsConfiguration.addAllowedHeader("*");
@@ -104,5 +102,8 @@ class FailedAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.getWriter().write("{\"code\": \"NP\", \"message\": \"No Permission.\"}");
+        System.out.println(authException.getMessage());
+        System.out.println(authException);
+        System.out.println(authException.getCause());
     }
 }

--- a/src/main/java/com/swyp/boardpick/controller/BoardGameController.java
+++ b/src/main/java/com/swyp/boardpick/controller/BoardGameController.java
@@ -1,10 +1,14 @@
 package com.swyp.boardpick.controller;
 
+import com.swyp.boardpick.domain.BoardGame;
 import com.swyp.boardpick.dto.response.BoardGameDto;
 import com.swyp.boardpick.service.implement.BoardGameService;
+import com.swyp.boardpick.service.implement.UserBoardGameService;
 import com.swyp.boardpick.service.implement.UserService;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,48 +19,124 @@ import java.util.List;
 public class BoardGameController {
 
     private final BoardGameService boardGameService;
+    private final UserBoardGameService userBoardGameService;
     private final UserService userService;
 
     @GetMapping("/{id}")
-    public ResponseEntity<BoardGameDto> getBoardGameById(@PathVariable Long id) {
-        return boardGameService.getBoardGameById(id)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.noContent().build());
+    public ResponseEntity<BoardGameDto> getBoardGameById(@PathVariable Long id, Authentication principal) {
+
+        BoardGame boardGame = boardGameService.getBoardGameById(id);
+        boolean picked = false;
+
+        if (principal != null) {
+            Long userId = userService.getUserId(principal.getName());
+            picked = userBoardGameService.getPicked(userId, id);
+        }
+
+        return ResponseEntity.ok(new BoardGameDto(boardGame, picked));
     }
 
     @GetMapping("/recs")
-    public ResponseEntity<List<BoardGameDto>> getRecommendations() {
-        List<BoardGameDto> recommendedBoardGames = boardGameService.recommendBoardGames();
+    public ResponseEntity<List<BoardGameDto>> getRecommendations(Authentication principal) {
+
+        List<BoardGame> recommendedBoardGames = boardGameService.recommendBoardGames();
+
         if (recommendedBoardGames.isEmpty())
             return ResponseEntity.noContent().build();
-        return ResponseEntity.ok(recommendedBoardGames);
+
+        if (principal == null) {
+            return ResponseEntity.ok(boardGameService.convertToDotListForAnonymous(recommendedBoardGames));
+        }
+        Long userId = userService.getUserId(principal.getName());
+
+        return ResponseEntity.ok(boardGameService.convertToDtoList(recommendedBoardGames, userId));
     }
 
     @GetMapping
     @ResponseBody
-    public List<BoardGameDto> getBoardgamesByCategory(
-            @RequestParam String category, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "1000") int size) {
-        return boardGameService.getBoardGamesByCategory(category, page, size);
+    public ResponseEntity<List<BoardGameDto>> getBoardgamesByCategory(Authentication principal,
+            @RequestParam String category, @RequestParam(defaultValue = "0") @Min(0) int page, @RequestParam(defaultValue = "1000") @Min(1) int size) {
+
+        List<BoardGame> boardGames = boardGameService.getBoardGamesByCategory(category, page, size);
+
+        if (boardGames.isEmpty())
+            return ResponseEntity.noContent().build();
+
+        if (principal == null) {
+            return ResponseEntity.ok(boardGameService.convertToDotListForAnonymous(boardGames));
+        }
+
+        Long userId = userService.getUserId(principal.getName());
+
+        return ResponseEntity.ok(boardGameService.convertToDtoList(boardGames, userId));
     }
 
     @GetMapping("/search")
-    public List<BoardGameDto> searchBoardGames(
-            @RequestParam String keyword, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "1000") int size) {
-        return boardGameService.searchBoardGamesByKeyword(keyword, page, size);
+    public ResponseEntity<List<BoardGameDto>> searchBoardGames(Authentication principal,
+            @RequestParam String keyword, @RequestParam(defaultValue = "0") @Min(0) int page, @RequestParam(defaultValue = "1000") @Min(1) int size) {
+
+        List<BoardGame> boardGames = boardGameService.searchBoardGamesByKeyword(keyword, page, size);
+
+        if (boardGames.isEmpty())
+            return ResponseEntity.noContent().build();
+
+        if (principal == null) {
+            return ResponseEntity.ok(boardGameService.convertToDotListForAnonymous(boardGames));
+        }
+
+        Long userId = userService.getUserId(principal.getName());
+
+        return ResponseEntity.ok(boardGameService.convertToDtoList(boardGames, userId));
     }
 
     @GetMapping("/today-pick")
-    public List<BoardGameDto> getTodayPick() {
-        return boardGameService.getTodayPick();
+    public ResponseEntity<List<BoardGameDto>> getTodayPick(Authentication principal) {
+
+        List<BoardGame> boardGames = boardGameService.getTodayPick();
+
+        if (boardGames.isEmpty())
+            return ResponseEntity.noContent().build();
+
+        if (principal == null) {
+            return ResponseEntity.ok(boardGameService.convertToDotListForAnonymous(boardGames));
+        }
+
+        Long userId = userService.getUserId(principal.getName());
+
+        return ResponseEntity.ok(boardGameService.convertToDtoList(boardGames, userId));
     }
 
     @GetMapping("/list")
-    public List<BoardGameDto> getTop10(@RequestParam String filter) {
-        return boardGameService.getTop10(filter);
+    public ResponseEntity<List<BoardGameDto>> getTop10(@RequestParam String filter, Authentication principal) {
+
+        List<BoardGame> boardGames = boardGameService.getTop10(filter);
+
+        if (boardGames.isEmpty())
+            return ResponseEntity.noContent().build();
+
+        if (principal == null) {
+            return ResponseEntity.ok(boardGameService.convertToDotListForAnonymous(boardGames));
+        }
+
+        Long userId = userService.getUserId(principal.getName());
+
+        return ResponseEntity.ok(boardGameService.convertToDtoList(boardGames, userId));
     }
 
-    @GetMapping("similar/{id}")
-    public List<BoardGameDto> similarBoardGames(@PathVariable Long id) {
-        return boardGameService.getSimilarBoardGamesById(id);
+    @GetMapping("/similar/{id}")
+    public ResponseEntity<List<BoardGameDto>> similarBoardGames(@PathVariable Long id, Authentication principal) {
+
+        List<BoardGame> boardGames = boardGameService.getSimilarBoardGamesById(id);
+
+        if (boardGames.isEmpty())
+            return ResponseEntity.noContent().build();
+
+        if (principal == null) {
+            return ResponseEntity.ok(boardGameService.convertToDotListForAnonymous(boardGames));
+        }
+
+        Long userId = userService.getUserId(principal.getName());
+
+        return ResponseEntity.ok(boardGameService.convertToDtoList(boardGames, userId));
     }
 }

--- a/src/main/java/com/swyp/boardpick/controller/UserBoardGameController.java
+++ b/src/main/java/com/swyp/boardpick/controller/UserBoardGameController.java
@@ -1,9 +1,11 @@
 package com.swyp.boardpick.controller;
 
+import com.swyp.boardpick.domain.BoardGame;
 import com.swyp.boardpick.domain.CustomOAuth2User;
 import com.swyp.boardpick.domain.User;
 import com.swyp.boardpick.dto.response.BoardGameDto;
 import com.swyp.boardpick.repository.UserRepository;
+import com.swyp.boardpick.service.implement.BoardGameService;
 import com.swyp.boardpick.service.implement.UserBoardGameService;
 import com.swyp.boardpick.service.implement.UserService;
 import jakarta.persistence.EntityNotFoundException;
@@ -26,23 +28,22 @@ public class UserBoardGameController {
     private final UserBoardGameService userBoardGameService;
     private final UserService userService;
     private final UserRepository userRepository;
+    private final BoardGameService boardGameService;
 
     @PostMapping("/{boardGameId}")
     public ResponseEntity<?> togglePick(@PathVariable("boardGameId") Long boardGameId, Authentication principal) {
         if (principal == null) {
 //            URI uri = URI.create(Uri.LOGIN_PAGE.getDescription());
 //            return ResponseEntity.status(HttpStatus.FOUND).location(uri).build();
+            System.out.println("principal is null");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-
         }
-        String userCode = principal.getName();
-        User user = userRepository.findByCode(userCode)
-                .orElseThrow(() -> new EntityNotFoundException("User not found with code: " + userCode));
-        Long userId = user.getId();
 
-        boolean isPicked = userBoardGameService.togglePick(userId, boardGameId);
+        Long userId = userService.getUserId(principal.getName());
 
-        return ResponseEntity.ok().body(Map.of("picked", isPicked));
+        boolean picked = userBoardGameService.togglePick(userId, boardGameId);
+
+        return ResponseEntity.ok().body(Map.of("picked", picked));
     }
 
     @GetMapping
@@ -51,11 +52,15 @@ public class UserBoardGameController {
         if (principal == null) {
 //            URI uri = URI.create(Uri.LOGIN_PAGE.getDescription());
 //            return ResponseEntity.status(HttpStatus.FOUND).location(uri).build();
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.noContent().build();
         }
 
-        Long id = userService.getUserId(principal.getName());
-        return ResponseEntity
-                .ok(userBoardGameService.getMyPickList(id));
+        Long userId = userService.getUserId(principal.getName());
+        List<BoardGame> boardGames = userBoardGameService.getMyPickList(userId);
+
+        if (boardGames.isEmpty())
+            return ResponseEntity.noContent().build();
+
+        return ResponseEntity.ok(boardGameService.convertToDtoList(boardGames, userId));
     }
 }

--- a/src/main/java/com/swyp/boardpick/controller/UserController.java
+++ b/src/main/java/com/swyp/boardpick/controller/UserController.java
@@ -27,7 +27,7 @@ public class UserController {
         if (principal == null) {
 //            URI uri = URI.create(Uri.LOGIN_PAGE.getDescription());
 //            return ResponseEntity.status(HttpStatus.FOUND).location(uri).build();
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.noContent().build();
         }
 
         Long userId = userService.getUserId(principal.getName());

--- a/src/main/java/com/swyp/boardpick/dto/response/BoardGameDto.java
+++ b/src/main/java/com/swyp/boardpick/dto/response/BoardGameDto.java
@@ -1,15 +1,9 @@
 package com.swyp.boardpick.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.swyp.boardpick.domain.*;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-
-import java.util.ArrayList;
 import java.util.List;
 
 @Builder
@@ -36,7 +30,7 @@ public class BoardGameDto {
     private List<UserBoardGame> userBoardGames;
     private List<String> tags;
 
-    public BoardGameDto(BoardGame boardGame, String difficulty, List<String> boardGameCategories, List<String> tags, boolean picked) {
+    public BoardGameDto(BoardGame boardGame, boolean picked) {
         this.id = boardGame.getId();
         this.thumbnailUrl = boardGame.getThumbnailUrl();
         this.imageUrl = boardGame.getImageUrl();
@@ -48,14 +42,30 @@ public class BoardGameDto {
         this.maxPlayers = boardGame.getMaxPlayers();
         this.playtime = boardGame.getPlaytime();
         this.ageLimit = boardGame.getAgeLimit();
-        this.difficulty = difficulty;
+        this.difficulty = convertDifficulty(boardGame.getDifficulty()).getDescription();
         this.rule = boardGame.getRule();
         this.extraVideo = boardGame.getExtraVideo();
         this.likes = boardGame.getLikes();
-        this.boardGameCategories = boardGameCategories;
+        this.boardGameCategories = boardGame.getBoardGameCategories()
+                .stream().map(boardGameCategory -> boardGameCategory.getCategory().getType())
+                .toList();
         this.userBoardGames = boardGame.getUserBoardGames();
-        this.tags = tags;
+        this.tags = boardGame.getBoardGameTags()
+                .stream().map(boardGameTag -> boardGameTag.getTag().getContent())
+                .toList();
         this.picked = picked;
+    }
+
+    private static Difficulty convertDifficulty(double difficulty) {
+        if (difficulty < 1.8)
+            return Difficulty.VERY_EASY;
+        if (difficulty < 2.6)
+            return Difficulty.EASY;
+        if (difficulty < 3.4)
+            return Difficulty.NORMAL;
+        if (difficulty < 4.2)
+            return Difficulty.HARD;
+        return Difficulty.VERY_HARD;
     }
 }
 

--- a/src/main/java/com/swyp/boardpick/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/swyp/boardpick/filter/JwtAuthenticationFilter.java
@@ -9,6 +9,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
@@ -30,6 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
+    private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/com/swyp/boardpick/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/swyp/boardpick/handler/OAuth2SuccessHandler.java
@@ -33,8 +33,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String code = oAuth2User.getName();
         String token = jwtProvider.create(code);
 
-        response.sendRedirect(frontBaseUrl + "/auth/oauth-success?token=" + token);
+//        response.sendRedirect(frontBaseUrl + "/auth/oauth-success?token=" + token);
 //        response.sendRedirect(frontBaseUrl);
-//        response.sendRedirect("http://localhost:3000");
+        response.sendRedirect("http://localhost:3000" + "/auth/oauth-success?token=" + token);
+//        response.sendRedirect("http://localhost:8080/" + token);
     }
 }

--- a/src/main/java/com/swyp/boardpick/service/implement/OAuth2UserServiceImplement.java
+++ b/src/main/java/com/swyp/boardpick/service/implement/OAuth2UserServiceImplement.java
@@ -5,8 +5,11 @@ import com.swyp.boardpick.domain.Role;
 import com.swyp.boardpick.domain.User;
 import com.swyp.boardpick.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -66,6 +69,19 @@ public class OAuth2UserServiceImplement extends DefaultOAuth2UserService {
             userRepository.save(user);
 
             return new CustomOAuth2User(userCode, authorities);
+        }
+
+        return null;
+    }
+
+    public OAuth2AuthenticationToken getOAuth2Token() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
+
+//            OAuth2User oauthUser = oauthToken.getPrincipal();
+//            return getUserId(oauthUser.getName());
+            return oauthToken;
         }
 
         return null;

--- a/src/main/java/com/swyp/boardpick/service/implement/UserBoardGameService.java
+++ b/src/main/java/com/swyp/boardpick/service/implement/UserBoardGameService.java
@@ -3,12 +3,11 @@ package com.swyp.boardpick.service.implement;
 import com.swyp.boardpick.domain.BoardGame;
 import com.swyp.boardpick.domain.User;
 import com.swyp.boardpick.domain.UserBoardGame;
-import com.swyp.boardpick.dto.response.BoardGameDto;
 import com.swyp.boardpick.repository.BoardGameRepository;
 import com.swyp.boardpick.repository.UserBoardGameRepository;
 import com.swyp.boardpick.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,11 +22,10 @@ public class UserBoardGameService {
     private final UserBoardGameRepository userBoardGameRepository;
     private final UserRepository userRepository;
     private final BoardGameRepository boardGameRepository;
-    private final BoardGameService boardGameService;
 
 
     @Transactional
-    public boolean togglePick(Long userId, Long boardGameId) {
+    public Boolean togglePick(Long userId, Long boardGameId) {
 
         Optional<BoardGame> optionalBoardGame = boardGameRepository.findById(boardGameId);
         if (optionalBoardGame.isEmpty())
@@ -58,14 +56,16 @@ public class UserBoardGameService {
         }
     }
 
-    public List<BoardGameDto> getMyPickList(Long id) {
+    public List<BoardGame> getMyPickList(Long id) {
         return userRepository.findById(id)
-                .get().getUserBoardGames()
-                .stream().map(userBoardGame -> {
-                    BoardGame boardGame = userBoardGame.getBoardGame();
-                    return boardGameService.convertToDto(boardGame);
-                })
+                .orElseThrow(() -> new EntityNotFoundException("User not found"))
+                .getUserBoardGames()
+                .stream().map(UserBoardGame::getBoardGame)
                 .toList();
+    }
+
+    public boolean getPicked(Long userId, Long boardGameId) {
+        return userBoardGameRepository.existsByUserIdAndBoardGameId(userId, boardGameId);
     }
 
 }

--- a/src/main/java/com/swyp/boardpick/service/implement/UserService.java
+++ b/src/main/java/com/swyp/boardpick/service/implement/UserService.java
@@ -33,18 +33,6 @@ public class UserService {
         return user.getId();
     }
 
-    public Long getCurrentOAuth2UserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
-
-            OAuth2User oauthUser = oauthToken.getPrincipal();
-            return getUserId(oauthUser.getName());
-        }
-
-        return null;
-    }
-
     public UserDto getMyInfo(Long id) {
         User user =  userRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));


### PR DESCRIPTION
#54 
## 작업 개요
jwt API 요청 인증 프로세스 수정

## 작업 사항
- `.requestMatchers(HttpMethod.POST, "/api/**").authenticated()` POST 요청에 대해 인증 요청
- API 요청에 대해 `Authentication`으로 유저 정보 가져와서 picked 반환
```java
@GetMapping("/{id}")
    public ResponseEntity<BoardGameDto> getBoardGameById(@PathVariable Long id, Authentication principal) {

        BoardGame boardGame = boardGameService.getBoardGameById(id);
        boolean picked = false;

        if (principal != null) {
            Long userId = userService.getUserId(principal.getName());
            picked = userBoardGameService.getPicked(userId, id);
        }

        return ResponseEntity.ok(new BoardGameDto(boardGame, picked));
    }
```
- `Entity -> Dto 변환` 과정을 `Service` 에서 `Controller`로 변경

