### PR TITLE
Fix: Handling youtube url edge case

### DIFF
--- a/src/main/java/com/swyp/boardpick/utils/BoardGameEntityListener.java
+++ b/src/main/java/com/swyp/boardpick/utils/BoardGameEntityListener.java
@@ -28,7 +28,7 @@ public class BoardGameEntityListener {
     }
 
     private String getUrlKey(String url) {
-        String pattern = "(?<=youtu.be/|v=)[^&#?]*";
+        String pattern = "(?<=youtu.be/|v=|live/|embed/|shorts/)[^&#?/]+";
 
         Pattern compiledPattern = Pattern.compile(pattern);
         Matcher matcher = compiledPattern.matcher(url);


### PR DESCRIPTION
close #44 
## 작업 개요
보드게임 상세페이지에 삽입할 youtube url 매칭 정규표현식 수정

## 작업 사항
```java
String pattern = "(?<=youtu.be/|v=|live/|embed/|shorts/)[^&#?/]+";
```
