### PR TITLE
Fix: 추천 보드게임 목록에서 이미 픽한것들 제외

### DIFF
--- a/src/main/java/com/swyp/boardpick/config/WebSecurityConfig.java
+++ b/src/main/java/com/swyp/boardpick/config/WebSecurityConfig.java
@@ -102,8 +102,5 @@ class FailedAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.getWriter().write("{\"code\": \"NP\", \"message\": \"No Permission.\"}");
-        System.out.println(authException.getMessage());
-        System.out.println(authException);
-        System.out.println(authException.getCause());
     }
 }

--- a/src/main/java/com/swyp/boardpick/controller/BoardGameController.java
+++ b/src/main/java/com/swyp/boardpick/controller/BoardGameController.java
@@ -41,32 +41,40 @@ public class BoardGameController {
 
         if (principal == null) {
             return ResponseEntity.ok(
-                    boardGameService.convertToDotListForAnonymous(
-                            boardGameService.getRandomBoardGames()
+                    boardGameService.convertToDtoListForAnonymous(
+                            boardGameService.getRandomBoardGames(10)
                     ));
         }
 
         Long userId = userService.getUserId(principal.getName());
-        List<BoardGame> recommendedBoardGames = boardGameService.getRecommendationBoardGamesByUser(userId);
 
-        if (recommendedBoardGames.size() < 10) {
+        List<BoardGame> recommendationBoardGames =
+                boardGameService.fillRandomBoardGames(
+                boardGameService.getRecommendationBoardGamesByUser(userId)
+                        , 10);
 
-            List<BoardGame> randomBoardGames = boardGameService.getRandomBoardGames();
-            randomBoardGames.removeAll(recommendedBoardGames);
-
-            int remainingSlots = 10 - recommendedBoardGames.size();
-            recommendedBoardGames.addAll(randomBoardGames.stream().limit(remainingSlots).toList());
-        }
-
-        return ResponseEntity.ok(boardGameService.convertToDtoList(recommendedBoardGames, userId));
+        return ResponseEntity.ok(boardGameService.convertToDtoList(recommendationBoardGames, userId));
     }
 
     @GetMapping("/suggestion")
-    public ResponseEntity<List<BoardGameDto>> getSuggestionBoardGames() {
+    public ResponseEntity<List<BoardGameDto>> getSuggestionBoardGames(Authentication principal) {
+
+        if (principal == null) {
+            return ResponseEntity.ok(
+                    boardGameService.convertToDtoListForAnonymous(
+                            boardGameService.getPopularBoardGames()
+                                    .stream().limit(10).toList()
+                    )
+            );
+        }
+
+        Long userId = userService.getUserId(principal.getName());
         return ResponseEntity.ok(
-                boardGameService.convertToDotListForAnonymous(
-                boardGameService.getPopularBoardGames()
-        ));
+                boardGameService.convertToDtoList(
+                        boardGameService.fillRandomBoardGames(
+                                boardGameService.getSuggestionBoardGames(userId), 10)
+                        , userId)
+        );
     }
 
     @GetMapping
@@ -80,7 +88,7 @@ public class BoardGameController {
             return ResponseEntity.noContent().build();
 
         if (principal == null) {
-            return ResponseEntity.ok(boardGameService.convertToDotListForAnonymous(boardGames));
+            return ResponseEntity.ok(boardGameService.convertToDtoListForAnonymous(boardGames));
         }
 
         Long userId = userService.getUserId(principal.getName());
@@ -98,7 +106,7 @@ public class BoardGameController {
             return ResponseEntity.noContent().build();
 
         if (principal == null) {
-            return ResponseEntity.ok(boardGameService.convertToDotListForAnonymous(boardGames));
+            return ResponseEntity.ok(boardGameService.convertToDtoListForAnonymous(boardGames));
         }
 
         Long userId = userService.getUserId(principal.getName());
@@ -115,7 +123,7 @@ public class BoardGameController {
             return ResponseEntity.noContent().build();
 
         if (principal == null) {
-            return ResponseEntity.ok(boardGameService.convertToDotListForAnonymous(boardGames));
+            return ResponseEntity.ok(boardGameService.convertToDtoListForAnonymous(boardGames));
         }
 
         Long userId = userService.getUserId(principal.getName());
@@ -132,7 +140,7 @@ public class BoardGameController {
             return ResponseEntity.noContent().build();
 
         if (principal == null) {
-            return ResponseEntity.ok(boardGameService.convertToDotListForAnonymous(boardGames));
+            return ResponseEntity.ok(boardGameService.convertToDtoListForAnonymous(boardGames));
         }
 
         Long userId = userService.getUserId(principal.getName());
@@ -149,7 +157,7 @@ public class BoardGameController {
             return ResponseEntity.noContent().build();
 
         if (principal == null) {
-            return ResponseEntity.ok(boardGameService.convertToDotListForAnonymous(boardGames));
+            return ResponseEntity.ok(boardGameService.convertToDtoListForAnonymous(boardGames));
         }
 
         Long userId = userService.getUserId(principal.getName());

--- a/src/main/java/com/swyp/boardpick/controller/UserBoardGameController.java
+++ b/src/main/java/com/swyp/boardpick/controller/UserBoardGameController.java
@@ -35,7 +35,6 @@ public class UserBoardGameController {
         if (principal == null) {
 //            URI uri = URI.create(Uri.LOGIN_PAGE.getDescription());
 //            return ResponseEntity.status(HttpStatus.FOUND).location(uri).build();
-            System.out.println("principal is null");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 

--- a/src/main/java/com/swyp/boardpick/repository/BoardGameRepository.java
+++ b/src/main/java/com/swyp/boardpick/repository/BoardGameRepository.java
@@ -40,6 +40,10 @@ public interface BoardGameRepository extends JpaRepository<BoardGame, Long> {
     @Query("SELECT bg FROM BoardGame bg JOIN bg.boardGameCategories bgc JOIN bgc.category c WHERE c IN :categories AND bg.id <> :boardGameId GROUP BY bg ORDER BY COUNT(c) DESC")
     List<BoardGame> findSimilarByCategories(@Param("categories") List<Category> categories, @Param("boardGameId") Long boardGameId);
 
-    @Query(value = "SELECT * FROM board_game ORDER BY RANDOM() LIMIT 10", nativeQuery = true)
-    List<BoardGame> findRandomBoardGames();
+    @Query(value = "SELECT * FROM board_game ORDER BY RAND()", nativeQuery = true)
+    List<BoardGame> findRandomBoardGames(Pageable pageable);
+
+    @Query("SELECT bg FROM BoardGame bg WHERE bg.id NOT IN :excludeIds ORDER BY RAND()")
+    List<BoardGame> findRandomBoardGamesExcluding(@Param("excludeIds") List<Long> excludeIds, Pageable pageable);
+
 }


### PR DESCRIPTION
## 작업 개요
- suggestion에서 이미 pick한 보드게임들 제외
- 10개가 안되면 나머지를 랜덤 보드게임으로 채워 넣기

## 작업 사항
```java
public List<BoardGame> fillRandomBoardGames(List<BoardGame> boardGames, Integer fullSize) {
        List<BoardGame> filledBoardGames = new ArrayList<>(boardGames);

        int size = fullSize - filledBoardGames.size();

        if (size > 0) {
            List<Long> existingIds = boardGames.stream()
                    .map(BoardGame::getId)
                    .toList();

            List<BoardGame> randomGames =
                    boardGameRepository.findRandomBoardGamesExcluding(existingIds, PageRequest.of(0, size));
            filledBoardGames.addAll(randomGames);
        }

        return filledBoardGames;
    }
```

## 고민한 점들
그냥 필요한 갯수만큼 랜덤을 뽑아오니 기존에 뽑아놓은 보드게임과 겹치는 문제 발생
-> `findRandomBoardGamesExcluding()`으로 기존에 뽑아 놓은건 제외하고 랜덤으로 가져오게 함

