### PR TITLE
Fix: 보드게임 영상 데이터가 안들어왔을 시 빈문자열로 처리

### DIFF
--- a/src/main/java/com/swyp/boardpick/repository/BoardGameRepository.java
+++ b/src/main/java/com/swyp/boardpick/repository/BoardGameRepository.java
@@ -1,7 +1,6 @@
 package com.swyp.boardpick.repository;
 
 import com.swyp.boardpick.domain.BoardGame;
-import com.swyp.boardpick.domain.BoardGameCategory;
 import com.swyp.boardpick.domain.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/swyp/boardpick/utils/BoardGameEntityListener.java
+++ b/src/main/java/com/swyp/boardpick/utils/BoardGameEntityListener.java
@@ -19,6 +19,9 @@ public class BoardGameEntityListener {
     }
 
     public String formattingYoutubeUrl(String url) {
+        if (url == null || url.isEmpty())
+            return "";
+
         String embedPrefix = "https://www.youtube.com/embed/";
         if (url.startsWith(embedPrefix))
             return url;


### PR DESCRIPTION
## 작업 개요
- 보드게임 rule이나 연관 영상의 링크가 null or "" 일 경우 ""로 저장되게 처리
- 기존 DB에 저장되어 있던 `https://www.youtube.com/embed/null`을 `''`로 변경

## 작업 사항
```java
public String formattingYoutubeUrl(String url) {
        if (url == null || url.isEmpty())
            return "";

        String embedPrefix = "https://www.youtube.com/embed/";
        if (url.startsWith(embedPrefix))
            return url;

        String baseUrl = "https://www.youtube.com/embed/";
        return baseUrl + getUrlKey(url);
    }
```